### PR TITLE
fix(desktop): pin nix.package to f6ca5dc5cb471b45553f8f464b940b73f0a058dc

### DIFF
--- a/hosts/hw/desktop.nix
+++ b/hosts/hw/desktop.nix
@@ -173,6 +173,7 @@
 
   nix.settings.max-jobs = 4;
   nix.settings.cores = 24;
+  nix.package = (builtins.getFlake "github:nixos/nix/f6ca5dc5cb471b45553f8f464b940b73f0a058dc").packages.${pkgs.stdenv.hostPlatform.system}.default;
 
   # end hw file stuff
 


### PR DESCRIPTION
Hopefully, fix the (or just a?) daemon deadlock-on-SSH-disconnect issue.

In draft just because I want this flagged/recognized as a thing/change/patch upstream. Not because I want/need this landed, really.